### PR TITLE
Fix parsing 1d arrays

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -107,7 +107,7 @@ function parseHeaderStr(headerStr) {
   const jsonHeader = headerStr
     .toLowerCase() // boolean literals: False -> false
     .replace('(','[').replace('),',']') // Python tuple to JS array: (10,) -> [10,]
-    .replace('[,','[1,]').replace(',]',',1]') // implicit dimensions: [10,] -> [10,1]
+    .replace(',]',']') // trailing comma (for 1-d array): [10,] -> [10]
     .replace(/'/g, '"'); // single quotes -> double quotes
   return JSON.parse(jsonHeader);
 }

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -21,11 +21,14 @@ describe('NumpyParser', () => {
 
     const dtypes = ["float32", "float64", "int8", "int16", "int32", "uint8", "uint16", "uint32"];
     const shapes = ["(1,)", "(4,)", "(1, 4)", "(4, 4)", "(4, 4, 4)"];
+    const jsShapes = [[1], [4], [1, 4], [4, 4], [4, 4, 4]];
     dtypes.forEach(function(dtype) {
-      shapes.forEach(function(shape) {
+      shapes.forEach(function(shape, si) {
         it('correctly parsers a ' + dtype + ' array of shape ' + shape, () => {
           const arrayBuffer = loadArrayBuffer(`./test/data/${dtype}-${shape}.npy`);
-          const { data: array } = fromArrayBuffer(arrayBuffer);
+          const { data: array, shape: gotShape } = fromArrayBuffer(arrayBuffer);
+
+          assert.deepEqual(gotShape, jsShapes[si]);
 
           if (dtype.includes("uint")) {
             assert.equal(sum(array), 42);


### PR DESCRIPTION
Previously, they would get parsed as (N, 1), instead of (N,)